### PR TITLE
feat: allow user to be configured. 

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -204,6 +204,11 @@ func (e *Engine) deployServiceProcess(ctx context.Context, svc *ServiceConfig, s
 			})
 		}
 
+		user := svc.Defaults.User
+		if process.User != "" {
+			user = svc.Defaults.User
+		}
+
 		portProtocolBinding := selectedPort + "/tcp"
 		containerConfig := &container.Config{
 			Cmd:   process.Command,
@@ -216,6 +221,7 @@ func (e *Engine) deployServiceProcess(ctx context.Context, svc *ServiceConfig, s
 				managedLabel:    "1",
 			},
 			ExposedPorts: nat.PortSet{},
+			User:         user,
 		}
 		hostConfig := &container.HostConfig{
 			PortBindings: nat.PortMap{},

--- a/deploy.go
+++ b/deploy.go
@@ -204,11 +204,6 @@ func (e *Engine) deployServiceProcess(ctx context.Context, svc *ServiceConfig, s
 			})
 		}
 
-		user := svc.Defaults.User
-		if process.User != "" {
-			user = process.User
-		}
-
 		portProtocolBinding := selectedPort + "/tcp"
 		containerConfig := &container.Config{
 			Cmd:   process.Command,
@@ -221,7 +216,7 @@ func (e *Engine) deployServiceProcess(ctx context.Context, svc *ServiceConfig, s
 				managedLabel:    "1",
 			},
 			ExposedPorts: nat.PortSet{},
-			User:         user,
+			User:         process.GetUser(),
 		}
 		hostConfig := &container.HostConfig{
 			PortBindings: nat.PortMap{},

--- a/deploy.go
+++ b/deploy.go
@@ -206,7 +206,7 @@ func (e *Engine) deployServiceProcess(ctx context.Context, svc *ServiceConfig, s
 
 		user := svc.Defaults.User
 		if process.User != "" {
-			user = svc.Defaults.User
+			user = process.User
 		}
 
 		portProtocolBinding := selectedPort + "/tcp"

--- a/run_task.go
+++ b/run_task.go
@@ -177,11 +177,6 @@ func (e *Engine) runTask(ctx context.Context, taskName string, task *ServiceTask
 		time.Now().Unix(),
 	)
 
-	user := svc.Defaults.User
-	if task.User != "" {
-		user = task.User
-	}
-
 	containerConfig := &container.Config{
 		Cmd:   task.Command,
 		Image: image,
@@ -196,7 +191,7 @@ func (e *Engine) runTask(ctx context.Context, taskName string, task *ServiceTask
 			managedLabel: "1",
 		},
 
-		User: user,
+		User: task.GetUser(),
 	}
 	hostConfig := &container.HostConfig{
 		Mounts: mounts,

--- a/run_task.go
+++ b/run_task.go
@@ -179,7 +179,7 @@ func (e *Engine) runTask(ctx context.Context, taskName string, task *ServiceTask
 
 	user := svc.Defaults.User
 	if task.User != "" {
-		user = svc.Defaults.User
+		user = task.User
 	}
 
 	containerConfig := &container.Config{

--- a/run_task.go
+++ b/run_task.go
@@ -177,9 +177,10 @@ func (e *Engine) runTask(ctx context.Context, taskName string, task *ServiceTask
 		time.Now().Unix(),
 	)
 
-	e.log.Info("creating container",
-		zap.String("taskRun", fullName),
-	)
+	user := svc.Defaults.User
+	if task.User != "" {
+		user = svc.Defaults.User
+	}
 
 	containerConfig := &container.Config{
 		Cmd:   task.Command,
@@ -194,6 +195,8 @@ func (e *Engine) runTask(ctx context.Context, taskName string, task *ServiceTask
 			taskLabel:    taskName,
 			managedLabel: "1",
 		},
+
+		User: user,
 	}
 	hostConfig := &container.HostConfig{
 		Mounts: mounts,
@@ -208,6 +211,9 @@ func (e *Engine) runTask(ctx context.Context, taskName string, task *ServiceTask
 		)
 	}
 
+	e.log.Info("creating container",
+		zap.String("taskRun", fullName),
+	)
 	createRes, err := e.docker.ContainerCreate(
 		ctx,
 		containerConfig,

--- a/service_config.go
+++ b/service_config.go
@@ -123,6 +123,8 @@ type NetworkConfig struct {
 }
 
 type ServiceProcessConfig struct {
+	parent *ServiceConfig
+
 	Image    string               `yaml:"image"`
 	ImageTag string               `yaml:"imageTag"`
 	Command  []string             `yaml:"command"`
@@ -152,7 +154,16 @@ func (spc ServiceProcessConfig) GetQuantity() int {
 	return 1
 }
 
+func (spc ServiceProcessConfig) GetUser() string {
+	if spc.User != "" {
+		return spc.User
+	}
+	return spc.parent.Defaults.User
+}
+
 type ServiceTaskConfig struct {
+	parent *ServiceConfig
+
 	Image       string               `yaml:"image"`
 	ImageTag    string               `yaml:"imageTag"`
 	Command     []string             `yaml:"command"`
@@ -166,6 +177,13 @@ type ServiceTaskConfig struct {
 	// The following formats are valid:
 	// [ user | user:group | uid | uid:gid | user:gid | uid:group ]
 	User string `yaml:"user"`
+}
+
+func (t *ServiceTaskConfig) GetUser() string {
+	if t.User != "" {
+		return t.User
+	}
+	return t.parent.Defaults.User
 }
 
 var (
@@ -238,6 +256,16 @@ func (e *Engine) loadServiceConfig(serviceName string) (*ServiceConfig, error) {
 
 	if err := cfg.Validate(e.validate); err != nil {
 		return nil, err
+	}
+
+	for processName, process := range cfg.Processes {
+		process.parent = cfg
+		cfg.Processes[processName] = process
+	}
+
+	for taskName, task := range cfg.Tasks {
+		task.parent = cfg
+		cfg.Tasks[taskName] = task
 	}
 
 	return cfg, nil

--- a/service_config.go
+++ b/service_config.go
@@ -81,6 +81,13 @@ type ServiceDefaultsConfig struct {
 	Env      map[string]string    `yaml:"env"`
 	Mounts   []ServiceMountConfig `yaml:"mounts"`
 	Network  NetworkConfig        `yaml:"network"`
+
+	// User allows the default User/Group to be specified for task and
+	// process containers.
+	//
+	// The following formats are valid:
+	// [ user | user:group | uid | uid:gid | user:gid | uid:group ]
+	User string `yaml:"user"`
 }
 
 type ServiceMountConfig struct {
@@ -127,6 +134,12 @@ type ServiceProcessConfig struct {
 	// Privileged grants all capabilities to the container.
 	Privileged bool `yaml:"privileged"`
 
+	// User allows the User/Group to be configured for the process container.
+	//
+	// The following formats are valid:
+	// [ user | user:group | uid | uid:gid | user:gid | uid:group ]
+	User string `yaml:"user"`
+
 	Network    NetworkConfig `yaml:"network"`
 	ReadyCheck *ready.Check  `yaml:"readyCheck"`
 }
@@ -147,6 +160,12 @@ type ServiceTaskConfig struct {
 	Env         map[string]string    `yaml:"env"`
 	Mounts      []ServiceMountConfig `yaml:"mounts"`
 	Network     NetworkConfig        `yaml:"network"`
+
+	// User allows the User/Group to be configured for the task container.
+	//
+	// The following formats are valid:
+	// [ user | user:group | uid | uid:gid | user:gid | uid:group ]
+	User string `yaml:"user"`
 }
 
 var (

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -40,3 +40,81 @@ func Test_findDefaultService(t *testing.T) {
 		})
 	}
 }
+
+func Test_ServiceProcessConfig_GetUser(t *testing.T) {
+	tests := []struct {
+		name string
+		spc  ServiceProcessConfig
+		want string
+	}{
+		{
+			name: "fallback",
+			spc: ServiceProcessConfig{
+				parent: &ServiceConfig{
+					Defaults: ServiceDefaultsConfig{
+						User: "fizz",
+					},
+				},
+			},
+			want: "fizz",
+		},
+		{
+			name: "overriden",
+			spc: ServiceProcessConfig{
+				parent: &ServiceConfig{
+					Defaults: ServiceDefaultsConfig{
+						User: "fizz",
+					},
+				},
+				User: "buzz",
+			},
+			want: "buzz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spc.GetUser()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_ServiceTaskConfig_GetUser(t *testing.T) {
+	tests := []struct {
+		name string
+		stc  ServiceTaskConfig
+		want string
+	}{
+		{
+			name: "fallback",
+			stc: ServiceTaskConfig{
+				parent: &ServiceConfig{
+					Defaults: ServiceDefaultsConfig{
+						User: "fizz",
+					},
+				},
+			},
+			want: "fizz",
+		},
+		{
+			name: "overriden",
+			stc: ServiceTaskConfig{
+				parent: &ServiceConfig{
+					Defaults: ServiceDefaultsConfig{
+						User: "fizz",
+					},
+				},
+				User: "buzz",
+			},
+			want: "buzz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.stc.GetUser()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Allows configuration of the user the same way docker handles ``--user`` 

The following formats are valid:
user | user:group | uid | uid:gid | user:gid | uid:group