### PR TITLE
tweak: adjust caddy config so HTTP redirects to HTTPS

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -74,7 +74,7 @@ func (cm *Manager) defaultConfiguration() ([]byte, error) {
 		HTTPSPort: cm.Config.Ports.HTTPS,
 		Servers: map[string]*caddyhttp.Server{
 			guvnorServerName: {
-				Listen: []string{":80", ":443"},
+				Listen: []string{":443"},
 				Routes: caddyhttp.RouteList{
 					caddyhttp.Route{
 						HandlersRaw: []json.RawMessage{


### PR DESCRIPTION
addresses #51 for new installs

Another PR will be released to allow this change to occur in existing installs