### PR TITLE
feat: add optional imagePull service configuration field

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -433,12 +433,14 @@ func (e *Engine) deployServiceProcess(
 	}
 
 	// Calculate and pull image for new containers
-	image, err := process.GetImage()
+	image, pull, err := process.GetImage()
 	if err != nil {
 		return err
 	}
-	if err := e.pullImage(ctx, image); err != nil {
-		return err
+	if pull {
+		if err = e.pullImage(ctx, image); err != nil {
+			return err
+		}
 	}
 
 	for i := 0; i < process.GetQuantity(); i++ {

--- a/run_task.go
+++ b/run_task.go
@@ -50,12 +50,14 @@ func (e *Engine) interactiveAttach(ctx context.Context, id string) (chan struct{
 }
 
 func (e *Engine) runTask(ctx context.Context, task *ServiceTaskConfig, svc *ServiceConfig, injectEnv map[string]string) error {
-	image, err := task.GetImage()
+	image, pull, err := task.GetImage()
 	if err != nil {
 		return err
 	}
-	if err := e.pullImage(ctx, image); err != nil {
-		return err
+	if pull {
+		if err = e.pullImage(ctx, image); err != nil {
+			return err
+		}
 	}
 
 	env := mergeEnv(


### PR DESCRIPTION
Required to run a service from a locally built container, for which a "docker
pull" command would fail.

This compliments the "image" and "imageTag" service configuration fields we
already have. If the imagePull field is not present, it defaults to "true".
Hence, you only need to set it provide any value when you want to disable the
image being pulled before a deployment or task execution.