### PR TITLE
fix: replace and remove pkg/errors

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -3,6 +3,7 @@ package caddy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,7 +20,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
 	"github.com/krystal/guvnor/ready"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/jimeh/go-golden v0.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.21.0
@@ -92,6 +91,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/service_config.go
+++ b/service_config.go
@@ -2,6 +2,7 @@ package guvnor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/go-playground/validator/v10"
 	"github.com/krystal/guvnor/ready"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 


### PR DESCRIPTION
# Replaces `pkg/errors`  with `errors`

`pkg/errors` is archived and I believe it's primary benefit over the std `errors` package is that it generates a stack trace. 

Given the locations it's currently used in I don't believe you're depending on that stack trace, feel free to close this if that's wrong. 
